### PR TITLE
Further description of sweeps for revision

### DIFF
--- a/analysis2_manuscript.tex
+++ b/analysis2_manuscript.tex
@@ -401,6 +401,10 @@
     This function augments a demographic model by introducing an advantageous mutation over a given time interval,
     at a given position along the sequence; and conditions the simulation such that the mutation is above a particular 
     frequency at the beginning and end of the sweep period.
+    The conditioning is implemented via rejection sampling; if the frequency of the advantageous allele 
+    drifts out of the prescribed bounds, the simulation is restarted from the introduction of 
+    the advantageous allele. If there are competing advantageous alleles (e.g. simultaneous sweeps at distinct loci) 
+    then the simulation is restarted from the introduction of the first of these.
     As this functionality is implemented on top of the existing \stdpopsim API, it may be combined with other 
     models of selection and demography to simulate the combined effects of multiple, disparate evolutionary processes
     on genetic variation in a population.
@@ -917,6 +921,37 @@
     (using attributes \texttt{dominance\_coeff\_list} and \texttt{dominance\_coeff\_breaks}).    
     For additional implementation details on the \texttt{DFE} class, see the {\stdpopsim docs} at
     \url{https://popsim-consortium.github.io/stdpopsim-docs/main/introduction.html}.
+
+
+    % NSP: added to address reviewer 1's comments asking for more detail. Not adding
+    % any detail regarding the lower-level interface (particular "extended events") as
+    % these may change.
+    \subsection*{Selective sweeps and rejection sampling}
+
+    Selective sweeps are implemented in the \slim engine by
+    introducing a mutation with a fitness effect of $h s$ where $h$ is the
+    dominance coefficient (as for the DFE model) and $s \geq 0$ is the
+    selection coefficient.  The allele is introduced in a given population at
+    a specified time and genomic position, and may be either globally or locally
+    adaptive (so that the fitness effect is confined to the population of
+    origin) over a fixed duration. To model sweeps from standing genetic
+    variation (so-called ``soft sweeps''), the allele may be introduced at a
+    given frequency, in which case carriers are selected at random at the
+    initiation of the sweep.
+
+    Crucially, the advantageous allele must remain extant over the course of
+    the sweep; this conditioning is accomplished via rejection sampling,
+    whereby the simulation is restarted from the onset of the sweep if the
+    allele drifts out of the population of origin (or alternatively, below a
+    user-specified frequency). If there are competing advantageous alleles
+    (simultaneous sweeps at distinct loci) and one of these drifts out of
+    bounds, then the simulation is restarted from the onset of the first sweep;
+    this avoids conditioning on particular (partial) allele frequency
+    trajectories for the remaining alleles.  A downside of this strategy is
+    that rejection becomes more likely with increasing numbers of simultaneous
+    sweeps or with hard-to-satisfy constraints; but it allows for greater
+    flexibility in sweep specification and for interoperability with the
+    \stdpopsim DFE model.
     
 
     \subsection*{Quality control and software development}


### PR DESCRIPTION
- A couple sentences in results describing rejection sampling strategy
- A section in the methods describing what's going on in greater detail
- I'm omitted description of the lower-level interface (extended events) which give the most flexibility, as these may change in the future
- Also omitted description of the API itself, as this is in the docs (and might change to a lesser degree)